### PR TITLE
Completion cleanup

### DIFF
--- a/src/main/java/rocks/cleanstone/game/command/CommandMessage.java
+++ b/src/main/java/rocks/cleanstone/game/command/CommandMessage.java
@@ -3,6 +3,7 @@ package rocks.cleanstone.game.command;
 import java.util.Collection;
 import java.util.List;
 
+import java.util.Optional;
 import rocks.cleanstone.player.Player;
 
 public interface CommandMessage {
@@ -21,6 +22,8 @@ public interface CommandMessage {
     Player requireTargetPlayer();
 
     String requireStringMessage(boolean optional);
+
+    <T> Optional<T> optionalParameter(Class<T> parameterClass);
 
     <T> T requireParameter(Class<T> parameterClass);
 

--- a/src/main/java/rocks/cleanstone/game/command/CommandRegistry.java
+++ b/src/main/java/rocks/cleanstone/game/command/CommandRegistry.java
@@ -22,7 +22,7 @@ public interface CommandRegistry {
     void registerCommandParameter(CommandParameter commandParameter);
 
     @Nullable
-    <T> CommandParameter<T> getCommandParameter(Class<T> parameterClass);
+    <T> CommandParameter<T> getCommandParameter(Class<? super T> parameterClass);
 
     Set<CommandParameter<?>> getCommandParameters();
 

--- a/src/main/java/rocks/cleanstone/game/command/CommandRegistry.java
+++ b/src/main/java/rocks/cleanstone/game/command/CommandRegistry.java
@@ -22,7 +22,7 @@ public interface CommandRegistry {
     void registerCommandParameter(CommandParameter commandParameter);
 
     @Nullable
-    <T> CommandParameter<? extends T> getCommandParameter(Class<T> parameterClass);
+    <T> CommandParameter<T> getCommandParameter(Class<T> parameterClass);
 
     Set<CommandParameter<?>> getCommandParameters();
 

--- a/src/main/java/rocks/cleanstone/game/command/NoValidTargetException.java
+++ b/src/main/java/rocks/cleanstone/game/command/NoValidTargetException.java
@@ -1,0 +1,14 @@
+package rocks.cleanstone.game.command;
+
+public class NoValidTargetException extends RuntimeException {
+    private final CommandSender sender;
+
+    public NoValidTargetException(CommandSender sender) {
+        super("a target was neither specified, nor is " + sender.getClass().getSimpleName() + " a valid target");
+        this.sender = sender;
+    }
+
+    public CommandSender getSender() {
+        return sender;
+    }
+}

--- a/src/main/java/rocks/cleanstone/game/command/SimpleCommand.java
+++ b/src/main/java/rocks/cleanstone/game/command/SimpleCommand.java
@@ -2,6 +2,7 @@ package rocks.cleanstone.game.command;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +38,16 @@ public class SimpleCommand implements Command {
         this.expectedParameterTypes = expectedParameterTypes;
     }
 
+    public SimpleCommand(String name, List<String> aliases, Class... expectedParameterTypes) {
+        this(name, aliases, null, expectedParameterTypes);
+    }
+
     public SimpleCommand(String name, CommandExecutor commandExecutor) {
         this(name, new ArrayList<>(), commandExecutor);
+    }
+
+    public SimpleCommand(String name, Class... expectedParameterTypes) {
+        this(name, Collections.emptyList(), expectedParameterTypes);
     }
 
     public SimpleCommand(String name, Collection<String> aliases) {

--- a/src/main/java/rocks/cleanstone/game/command/SimpleCommandMessage.java
+++ b/src/main/java/rocks/cleanstone/game/command/SimpleCommandMessage.java
@@ -1,6 +1,5 @@
 package rocks.cleanstone.game.command;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/rocks/cleanstone/game/command/SimpleCommandRegistry.java
+++ b/src/main/java/rocks/cleanstone/game/command/SimpleCommandRegistry.java
@@ -4,18 +4,14 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Async;
-
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nullable;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
 import rocks.cleanstone.core.CleanstoneServer;
 import rocks.cleanstone.game.command.executor.HelpPageExecutor;
 import rocks.cleanstone.game.command.parameter.CommandParameter;
@@ -64,7 +60,9 @@ public class SimpleCommandRegistry implements CommandRegistry {
 
     private boolean isRegisteredCommandName(String name) {
         Command command = getCommand(name);
-        if (command == null) return false;
+        if (command == null) {
+            return false;
+        }
         return command.getName().equalsIgnoreCase(name);
     }
 
@@ -94,9 +92,9 @@ public class SimpleCommandRegistry implements CommandRegistry {
 
     @Override
     @Nullable
-    public <T> CommandParameter<? extends T> getCommandParameter(Class<T> parameterClass) {
+    public <T> CommandParameter<T> getCommandParameter(Class<T> parameterClass) {
         //noinspection unchecked
-        return (CommandParameter<? extends T>) commandParameters.stream().filter(
+        return (CommandParameter<T>) commandParameters.stream().filter(
                 parameter -> parameter.getParameterClass().isAssignableFrom(parameterClass)).findFirst().orElse(null);
     }
 

--- a/src/main/java/rocks/cleanstone/game/command/SimpleCommandRegistry.java
+++ b/src/main/java/rocks/cleanstone/game/command/SimpleCommandRegistry.java
@@ -92,7 +92,7 @@ public class SimpleCommandRegistry implements CommandRegistry {
 
     @Override
     @Nullable
-    public <T> CommandParameter<T> getCommandParameter(Class<T> parameterClass) {
+    public <T> CommandParameter<T> getCommandParameter(Class<? super T> parameterClass) {
         //noinspection unchecked
         return (CommandParameter<T>) commandParameters.stream().filter(
                 parameter -> parameter.getParameterClass().isAssignableFrom(parameterClass)).findFirst().orElse(null);

--- a/src/main/java/rocks/cleanstone/game/command/cleanstone/AlertCommand.java
+++ b/src/main/java/rocks/cleanstone/game/command/cleanstone/AlertCommand.java
@@ -14,7 +14,7 @@ public class AlertCommand extends SimpleCommand {
     private final PlayerManager playerManager;
 
     public AlertCommand(PlayerManager playerManager) {
-        super("alert", Arrays.asList("say", "broadcast"));
+        super("alert", Arrays.asList("say", "broadcast"), String.class);
         this.playerManager = playerManager;
     }
 
@@ -30,10 +30,5 @@ public class AlertCommand extends SimpleCommand {
         String input = message.requireStringMessage(false);
         String alertMessage = CleanstoneServer.getMessage("game.command.cleanstone.alert-format", input);
         playerManager.getOnlinePlayers().forEach(player -> player.sendMessage(Text.of(alertMessage)));
-    }
-
-    @Override
-    public Class[] getExpectedParameterTypes() {
-        return new Class[]{String.class};
     }
 }

--- a/src/main/java/rocks/cleanstone/game/command/cleanstone/GameModeCommand.java
+++ b/src/main/java/rocks/cleanstone/game/command/cleanstone/GameModeCommand.java
@@ -13,7 +13,7 @@ import rocks.cleanstone.player.Player;
 public class GameModeCommand extends SimpleCommand {
 
     public GameModeCommand() {
-        super("gamemode", Collections.singletonList("gm"));
+        super("gamemode", Collections.singletonList("gm"), VanillaGameMode.class, Player.class);
     }
 
     @Override
@@ -33,10 +33,5 @@ public class GameModeCommand extends SimpleCommand {
             message.getCommandSender().sendMessage(CleanstoneServer.getMessage(
                     "game.command.cleanstone.changed-gamemode", target.getId().getName(), gameMode.getName()));
         }
-    }
-
-    @Override
-    public Class[] getExpectedParameterTypes() {
-        return new Class[]{VanillaGameMode.class, Player.class};
     }
 }

--- a/src/main/java/rocks/cleanstone/game/command/cleanstone/KickCommand.java
+++ b/src/main/java/rocks/cleanstone/game/command/cleanstone/KickCommand.java
@@ -9,7 +9,7 @@ import rocks.cleanstone.player.Player;
 public class KickCommand extends SimpleCommand {
 
     public KickCommand() {
-        super("kick");
+        super("kick", Player.class, String.class);
     }
 
     @Override
@@ -22,10 +22,8 @@ public class KickCommand extends SimpleCommand {
         }
 
         Player target = message.requireParameter(Player.class);
-        String reason;
-        if (message.isParameterPresent(String.class)) {
-            reason = message.requireParameter(String.class);
-        } else reason = CleanstoneServer.getMessage("game.command.cleanstone.default-kick-reason");
+        String reason = message.optionalParameter(String.class)
+                .orElseGet(() -> CleanstoneServer.getMessage("game.command.cleanstone.default-kick-reason"));
         target.kick(Text.of(reason));
         message.getCommandSender().sendMessage(Text.of(CleanstoneServer.getMessage(
                 "game.command.cleanstone.kicked-player", target.getId().getName(), reason)));

--- a/src/main/java/rocks/cleanstone/game/command/cleanstone/StopCommand.java
+++ b/src/main/java/rocks/cleanstone/game/command/cleanstone/StopCommand.java
@@ -12,7 +12,7 @@ public class StopCommand extends SimpleCommand {
     private final PlayerManager playerManager;
 
     public StopCommand(PlayerManager playerManager) {
-        super("stop");
+        super("stop", String.class);
         this.playerManager = playerManager;
     }
 
@@ -34,10 +34,5 @@ public class StopCommand extends SimpleCommand {
         playerManager.getOnlinePlayers().forEach(player -> player.kick(reasonText));
 
         System.exit(0);
-    }
-
-    @Override
-    public Class[] getExpectedParameterTypes() {
-        return new Class[]{String.class};
     }
 }

--- a/src/main/java/rocks/cleanstone/game/command/completion/CompletableParameter.java
+++ b/src/main/java/rocks/cleanstone/game/command/completion/CompletableParameter.java
@@ -1,0 +1,8 @@
+package rocks.cleanstone.game.command.completion;
+
+import java.util.List;
+import rocks.cleanstone.game.command.parameter.CommandParameter;
+
+public interface CompletableParameter<T> extends CommandParameter<T> {
+    List<String> getCompletion(CompletionContext<T> context);
+}

--- a/src/main/java/rocks/cleanstone/game/command/completion/CompletableValue.java
+++ b/src/main/java/rocks/cleanstone/game/command/completion/CompletableValue.java
@@ -1,7 +1,0 @@
-package rocks.cleanstone.game.command.completion;
-
-import java.util.List;
-
-public interface CompletableValue<T> {
-    List<String> getCompletion(Class<T> parameterClass, String message);
-}

--- a/src/main/java/rocks/cleanstone/game/command/completion/CompletionContext.java
+++ b/src/main/java/rocks/cleanstone/game/command/completion/CompletionContext.java
@@ -1,0 +1,7 @@
+package rocks.cleanstone.game.command.completion;
+
+public interface CompletionContext<T> {
+    String getInput();
+
+    Class<T> getExpectedType();
+}

--- a/src/main/java/rocks/cleanstone/game/command/completion/SimpleCommandCompletion.java
+++ b/src/main/java/rocks/cleanstone/game/command/completion/SimpleCommandCompletion.java
@@ -69,34 +69,34 @@ public class SimpleCommandCompletion implements CommandCompletion {
     }
 
     private <T> List<String> completeParameter(CommandMessage commandMessage, Command command) {
-        List<String> parameters = new LinkedList<>(commandMessage.getParameters());
-        int lastParameterIndex = parameters.size() - 1;
+        List<String> parameterValues = new LinkedList<>(commandMessage.getParameters());
+        int lastParameterIndex = parameterValues.size() - 1;
 
         // complete next parameter when command ends in space
         if (commandMessage.getFullMessage().endsWith(" ")) {
-            parameters.add("");
+            parameterValues.add("");
             lastParameterIndex++;
         }
 
-        Class[] expectedParameterTypes = command.getExpectedParameterTypes();
+        Class<?>[] expectedParameterTypes = command.getExpectedParameterTypes();
 
         // not completing any parameter or completing too many parameters
-        if (lastParameterIndex < 0 || expectedParameterTypes.length <= lastParameterIndex) {
+        if (lastParameterIndex < 0 || lastParameterIndex >= expectedParameterTypes.length) {
             return Collections.emptyList();
         }
 
         //noinspection unchecked
-        Class<T> parameterType = expectedParameterTypes[lastParameterIndex];
-        String lastParameter = parameters.get(lastParameterIndex);
+        Class<T> parameterType = (Class<T>) expectedParameterTypes[lastParameterIndex];
+        String lastParameterValue = parameterValues.get(lastParameterIndex);
 
-        CommandParameter<? extends T> commandParameter = commandRegistry.getCommandParameter(parameterType);
+        CommandParameter<T> commandParameter = commandRegistry.getCommandParameter(parameterType);
 
         // check if parameter is completable
-        if (!(commandParameter instanceof CompletableValue)) {
+        if (!(commandParameter instanceof CompletableParameter)) {
             return Collections.emptyList();
         }
 
-        //noinspection unchecked
-        return ((CompletableValue<T>) commandParameter).getCompletion(parameterType, lastParameter);
+        CompletionContext<T> context = new SimpleCompletionContext<>(lastParameterValue, parameterType);
+        return ((CompletableParameter<T>) commandParameter).getCompletion(context);
     }
 }

--- a/src/main/java/rocks/cleanstone/game/command/completion/SimpleCompletionContext.java
+++ b/src/main/java/rocks/cleanstone/game/command/completion/SimpleCompletionContext.java
@@ -1,0 +1,21 @@
+package rocks.cleanstone.game.command.completion;
+
+public class SimpleCompletionContext<T> implements CompletionContext<T> {
+    private final String input;
+    private final Class<T> expectedType;
+
+    public SimpleCompletionContext(String input, Class<T> expectedType) {
+        this.input = input;
+        this.expectedType = expectedType;
+    }
+
+    @Override
+    public String getInput() {
+        return input;
+    }
+
+    @Override
+    public Class<T> getExpectedType() {
+        return expectedType;
+    }
+}

--- a/src/main/java/rocks/cleanstone/game/command/parameter/CommandParameter.java
+++ b/src/main/java/rocks/cleanstone/game/command/parameter/CommandParameter.java
@@ -1,15 +1,11 @@
 package rocks.cleanstone.game.command.parameter;
 
 import javax.annotation.Nullable;
+import rocks.cleanstone.game.command.completion.CompletionContext;
 
 public interface CommandParameter<T> {
     @Nullable
-    T get(String parameter);
-
-    @Nullable
-    default T get(Class<? super T> parameterClass, String parameter) {
-        return get(parameter);
-    }
+    T get(CompletionContext<T> context);
 
     Class getParameterClass();
 }

--- a/src/main/java/rocks/cleanstone/game/command/parameter/EnumParameter.java
+++ b/src/main/java/rocks/cleanstone/game/command/parameter/EnumParameter.java
@@ -1,39 +1,45 @@
 package rocks.cleanstone.game.command.parameter;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import rocks.cleanstone.game.command.completion.CompletableValue;
+import rocks.cleanstone.game.command.completion.CompletableParameter;
+import rocks.cleanstone.game.command.completion.CompletionContext;
 
-public class EnumParameter<T extends Enum<T>> implements CommandParameter<T>, CompletableValue<T> {
+public class EnumParameter<T extends Enum<T>> implements CompletableParameter<T> {
 
     @Override
-    public List<String> getCompletion(Class<T> parameterClass, String message) {
-        return Arrays.stream(parameterClass.getEnumConstants())
+    public List<String> getCompletion(CompletionContext<T> context) {
+        //noinspection unchecked
+        T[] enumConstants = context.getExpectedType().getEnumConstants();
+
+        try {
+            int ordinal = Integer.parseInt(context.getInput());
+
+            if (ordinal >= 0 && ordinal < enumConstants.length) {
+                return Collections.singletonList(enumConstants[ordinal].toString().toLowerCase(Locale.ENGLISH));
+            }
+        } catch (NumberFormatException ignored) { // not a number, try string completion
+        }
+
+        return Arrays.stream(enumConstants)
                 .map(Enum::toString)
                 .map(c -> c.toLowerCase(Locale.ENGLISH))
-                .filter(enumValue -> enumValue.startsWith(message.toLowerCase(Locale.ENGLISH)))
+                .filter(enumValue -> enumValue.startsWith(context.getInput().toLowerCase(Locale.ENGLISH)))
                 .collect(Collectors.toList());
     }
 
     @Nullable
     @Override
-    public T get(String parameter) {
-        throw new UnsupportedOperationException("can't get EnumParameter without parameterClass");
-    }
-
-    @Nullable
-    @Override
-    public T get(Class<? super T> parameterClass, String parameter) {
-        String lowercaseParameter = parameter.toLowerCase(Locale.ENGLISH);
-        //noinspection unchecked
-        return (T) Arrays.stream(parameterClass.getEnumConstants())
-                .filter(enumEntry -> enumEntry.toString().toLowerCase(Locale.ENGLISH)
-                        .startsWith(lowercaseParameter))
+    public T get(CompletionContext<T> context) {
+        return getCompletion(context).stream()
+                .map(completion -> completion.toUpperCase(Locale.ENGLISH))
+                .map(completion -> Enum.valueOf(context.getExpectedType(), completion))
                 .findFirst()
                 .orElse(null);
     }

--- a/src/main/java/rocks/cleanstone/game/command/parameter/IntParameter.java
+++ b/src/main/java/rocks/cleanstone/game/command/parameter/IntParameter.java
@@ -1,13 +1,14 @@
 package rocks.cleanstone.game.command.parameter;
 
 import javax.annotation.Nullable;
+import rocks.cleanstone.game.command.completion.CompletionContext;
 
 public class IntParameter implements CommandParameter<Integer> {
     @Nullable
     @Override
-    public Integer get(String parameter) {
+    public Integer get(CompletionContext<Integer> context) {
         try {
-            return Integer.parseInt(parameter);
+            return Integer.parseInt(context.getInput());
         } catch (NumberFormatException e) {
             return null;
         }

--- a/src/main/java/rocks/cleanstone/game/command/parameter/PlayerParameter.java
+++ b/src/main/java/rocks/cleanstone/game/command/parameter/PlayerParameter.java
@@ -4,11 +4,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import rocks.cleanstone.game.command.completion.CompletableValue;
+import rocks.cleanstone.game.command.completion.CompletableParameter;
+import rocks.cleanstone.game.command.completion.CompletionContext;
 import rocks.cleanstone.player.Player;
 import rocks.cleanstone.player.PlayerManager;
 
-public class PlayerParameter implements CommandParameter<Player>, CompletableValue<Player> {
+public class PlayerParameter implements CompletableParameter<Player> {
 
     private final PlayerManager playerManager;
 
@@ -18,8 +19,8 @@ public class PlayerParameter implements CommandParameter<Player>, CompletableVal
 
     @Nullable
     @Override
-    public Player get(String parameter) {
-        return playerManager.getOnlinePlayer(parameter);
+    public Player get(CompletionContext<Player> context) {
+        return playerManager.getOnlinePlayer(context.getInput());
     }
 
     @Override
@@ -28,11 +29,11 @@ public class PlayerParameter implements CommandParameter<Player>, CompletableVal
     }
 
     @Override
-    public List<String> getCompletion(Class<Player> parameterClass, String message) {
+    public List<String> getCompletion(CompletionContext<Player> context) {
         return playerManager.getOnlinePlayers().stream()
                 .map(player -> player.getId().getName())
                 .filter(playerName -> playerName.toLowerCase(Locale.ENGLISH)
-                        .startsWith(message.toLowerCase(Locale.ENGLISH)))
+                        .startsWith(context.getInput().toLowerCase(Locale.ENGLISH)))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/rocks/cleanstone/game/command/parameter/StringParameter.java
+++ b/src/main/java/rocks/cleanstone/game/command/parameter/StringParameter.java
@@ -1,12 +1,13 @@
 package rocks.cleanstone.game.command.parameter;
 
 import javax.annotation.Nullable;
+import rocks.cleanstone.game.command.completion.CompletionContext;
 
 public class StringParameter implements CommandParameter<String> {
     @Nullable
     @Override
-    public String get(String parameter) {
-        return parameter;
+    public String get(CompletionContext<String> context) {
+        return context.getInput();
     }
 
     @Override


### PR DESCRIPTION
Features:
- Enum completion by ordinal
- Command alias completion

Internals:
- Use `CompletionContext` instead of String/ParameterType combination
- Provide accessor for optional parameters in `CommandMessage`
- Move `SimpleCommand` parameter initialization into super-call