### PR TITLE
Remove blockDataStorage from simpleChunk?

### DIFF
--- a/src/main/java/rocks/cleanstone/game/world/chunk/Chunk.java
+++ b/src/main/java/rocks/cleanstone/game/world/chunk/Chunk.java
@@ -42,7 +42,5 @@ public interface Chunk {
 
     BlockDataTable getBlockDataTable();
 
-    BlockDataStorage getBlockDataStorage();
-
     EntityData getEntityData();
 }

--- a/src/main/java/rocks/cleanstone/game/world/chunk/SimpleChunk.java
+++ b/src/main/java/rocks/cleanstone/game/world/chunk/SimpleChunk.java
@@ -11,16 +11,13 @@ import java.util.Collection;
 public class SimpleChunk implements Chunk {
 
     private final BlockDataTable blockDataTable;
-    private final BlockDataStorage blockDataStorage;
     private final EntityData entityData;
     private final int x, z;
     private boolean hasUnsavedChanges = false;
     // TODO biome state
 
-    public SimpleChunk(BlockDataTable blockDataTable, BlockDataStorage blockDataStorage,
-                       EntityData entityData, int x, int z) {
+    public SimpleChunk(BlockDataTable blockDataTable, EntityData entityData, int x, int z) {
         this.blockDataTable = blockDataTable;
-        this.blockDataStorage = blockDataStorage;
         this.entityData = entityData;
         this.x = x;
         this.z = z;
@@ -62,7 +59,6 @@ public class SimpleChunk implements Chunk {
         validateRelativeBlockCoordinates(x, y, z);
         blockDataTable.setBlock(x, y, z, block);
         // TODO run the following expensive operation async
-        blockDataStorage.setBlockState(x, y, z, block.getState());
         hasUnsavedChanges = true;
     }
 
@@ -76,7 +72,6 @@ public class SimpleChunk implements Chunk {
     public void setBlockLight(int x, int y, int z, byte blockLight) {
         validateRelativeBlockCoordinates(x, y, z);
         blockDataTable.setBlockLight(x, y, z, blockLight);
-        blockDataStorage.setBlockLight(x, y, z, blockLight);
         hasUnsavedChanges = true;
     }
 
@@ -91,7 +86,6 @@ public class SimpleChunk implements Chunk {
         validateRelativeBlockCoordinates(x, y, z);
         if (!hasSkylight()) return;
         blockDataTable.setSkyLight(x, y, z, skyLight);
-        blockDataStorage.setSkyLight(x, y, z, skyLight);
         hasUnsavedChanges = true;
     }
 
@@ -113,11 +107,6 @@ public class SimpleChunk implements Chunk {
     @Override
     public BlockDataTable getBlockDataTable() {
         return blockDataTable;
-    }
-
-    @Override
-    public BlockDataStorage getBlockDataStorage() {
-        return blockDataStorage;
     }
 
     private void validateRelativeBlockCoordinates(int x, int y, int z) {

--- a/src/main/java/rocks/cleanstone/game/world/data/LevelDBWorldDataSourceFactory.java
+++ b/src/main/java/rocks/cleanstone/game/world/data/LevelDBWorldDataSourceFactory.java
@@ -1,15 +1,15 @@
 package rocks.cleanstone.game.world.data;
 
+import java.io.File;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import rocks.cleanstone.game.entity.EntityTypeRegistry;
 import rocks.cleanstone.game.world.chunk.data.block.vanilla.VanillaBlockDataCodecFactory;
+import rocks.cleanstone.game.world.chunk.data.block.vanilla.VanillaBlockDataStorageFactory;
 import rocks.cleanstone.net.minecraft.protocol.v1_13.ProtocolBlockStateMapping;
-
-import java.io.File;
-import java.io.IOException;
 
 @Component
 @ConditionalOnProperty(name = "world.datasource", havingValue = "leveldb", matchIfMissing = true)
@@ -17,15 +17,18 @@ public class LevelDBWorldDataSourceFactory implements WorldDataSourceFactory {
     private final Logger logger = LoggerFactory.getLogger(LevelDBWorldDataSourceFactory.class);
     private final ProtocolBlockStateMapping blockStateMapping;
     private final VanillaBlockDataCodecFactory vanillaBlockDataCodecFactory;
+    private final VanillaBlockDataStorageFactory vanillaBlockDataStorageFactory;
     private final EntityTypeRegistry entityTypeRegistry;
 
     public LevelDBWorldDataSourceFactory(
             ProtocolBlockStateMapping blockStateMapping,
             VanillaBlockDataCodecFactory vanillaBlockDataCodecFactory,
+            VanillaBlockDataStorageFactory vanillaBlockDataStorageFactory,
             EntityTypeRegistry entityTypeRegistry
     ) {
         this.blockStateMapping = blockStateMapping;
         this.vanillaBlockDataCodecFactory = vanillaBlockDataCodecFactory;
+        this.vanillaBlockDataStorageFactory = vanillaBlockDataStorageFactory;
         this.entityTypeRegistry = entityTypeRegistry;
     }
 
@@ -38,7 +41,7 @@ public class LevelDBWorldDataSourceFactory implements WorldDataSourceFactory {
             logger.error("Cannot create data folder (no permission?)", e);
         }
 
-        return new LevelDBWorldDataSource(vanillaBlockDataCodecFactory, entityTypeRegistry, blockStateMapping,
-                dataFolder, worldID);
+        return new LevelDBWorldDataSource(vanillaBlockDataCodecFactory, vanillaBlockDataStorageFactory,
+                entityTypeRegistry, blockStateMapping, dataFolder, worldID);
     }
 }

--- a/src/main/java/rocks/cleanstone/game/world/generation/FlatWorldGenerator.java
+++ b/src/main/java/rocks/cleanstone/game/world/generation/FlatWorldGenerator.java
@@ -22,15 +22,10 @@ import java.util.HashSet;
 public class FlatWorldGenerator extends AbstractWorldGenerator {
 
     private BlockDataTable blockDataTable;
-    private VanillaBlockDataStorage blockDataStorage;
-    private final VanillaBlockDataStorageFactory vanillaBlockDataStorageFactory;
 
     @Autowired
-    public FlatWorldGenerator(
-            VanillaBlockDataStorageFactory vanillaBlockDataStorageFactory
-    ) {
+    public FlatWorldGenerator() {
         super(Dimension.OVERWORLD, LevelType.FLAT);
-        this.vanillaBlockDataStorageFactory = vanillaBlockDataStorageFactory;
 
         blockDataTable = new ArrayBlockDataTable(true);
         for (int x = 0; x < 16; x++) {
@@ -46,15 +41,12 @@ public class FlatWorldGenerator extends AbstractWorldGenerator {
                 }
             }
         }
-
-        DirectPalette directPalette = new DirectPalette(new ProtocolBlockStateMapping(), 14);
-        blockDataStorage = vanillaBlockDataStorageFactory.get(blockDataTable, directPalette, true);
     }
 
     @Override
     public Chunk generateChunk(int seed, int chunkX, int chunkZ) {
         return new SimpleChunk(new ArrayBlockDataTable((ArrayBlockDataTable) blockDataTable),
-                vanillaBlockDataStorageFactory.get(blockDataStorage), new EntityData(new HashSet<>()), chunkX, chunkZ);
+                new EntityData(new HashSet<>()), chunkX, chunkZ);
     }
 
     @Override

--- a/src/main/java/rocks/cleanstone/game/world/generation/MountainWorldGenerator.java
+++ b/src/main/java/rocks/cleanstone/game/world/generation/MountainWorldGenerator.java
@@ -79,6 +79,7 @@ public class MountainWorldGenerator extends AbstractWorldGenerator {
     @Override
     public Chunk generateChunk(int seed, int chunkX, int chunkZ) {
         noiseGenerator.SetSeed(seed);
+
         BlockDataTable blockDataTable = new ArrayBlockDataTable(true);
         for (int x = 0; x < 16; x++) {
             for (int z = 0; z < 16; z++) {
@@ -97,11 +98,8 @@ public class MountainWorldGenerator extends AbstractWorldGenerator {
                 }
             }
         }
-        DirectPalette directPalette = new DirectPalette(blockStateMapping, 14);
-        VanillaBlockDataStorage blockDataStorage = vanillaBlockDataStorageFactory.get(blockDataTable,
-                directPalette, true);
 
-        return new SimpleChunk(blockDataTable, blockDataStorage, new EntityData(new HashSet<>()), chunkX, chunkZ);
+        return new SimpleChunk(blockDataTable, new EntityData(new HashSet<>()), chunkX, chunkZ);
     }
 
     public int getHeightAt(int seed, int x, int z) {


### PR DESCRIPTION
I have no idea if this is wanted, but it wasn't really needed anymore and took quite a bit of time at chunk generation.
This makes the chunk saving slower though, as the generation needs to be done there now instead.

If this is required or useful in a way I couldn't see just close the PR.